### PR TITLE
refactor(devenv): switch to nixpkgs-unstable repository.

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -110,17 +110,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716977621,
-        "owner": "cachix",
-        "repo": "devenv-nixpkgs",
-        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
-        "treeHash": "6d9f1f7ca0faf1bc2eeb397c78a49623260d3412",
+        "lastModified": 1725194671,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
+        "treeHash": "bb5efa178da5cad3d41f9557a800b8fa3033c1f5",
         "type": "github"
       },
       "original": {
-        "owner": "cachix",
-        "ref": "rolling",
-        "repo": "devenv-nixpkgs",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -7,4 +7,4 @@ inputs:
   mk-shell-bin:
     url: github:rrbutani/nix-mk-shell-bin
   nixpkgs:
-    url: github:cachix/devenv-nixpkgs/rolling
+    url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/includes/base.nix.jinja
+++ b/includes/base.nix.jinja
@@ -40,9 +40,8 @@
 
   # https://devenv.sh/pre-commit-hooks/
   pre-commit.hooks = {
-    nixfmt = {
+    nixfmt-rfc-style = {
       enable = true;
-      package = pkgs.nixfmt-rfc-style;
       excludes = [ ".devenv.flake.nix" ];
     };
     yamllint = {

--- a/includes/devenv.yaml
+++ b/includes/devenv.yaml
@@ -7,4 +7,4 @@ inputs:
   mk-shell-bin:
     url: github:rrbutani/nix-mk-shell-bin
   nixpkgs:
-    url: github:cachix/devenv-nixpkgs/rolling
+    url: github:NixOS/nixpkgs/nixpkgs-unstable


### PR DESCRIPTION
This is due to cachix/devenv-nixpkgs#8.