### PR TITLE
Python precommits and other goodies

### DIFF
--- a/includes/base.nix.jinja
+++ b/includes/base.nix.jinja
@@ -6,22 +6,45 @@
   ...
 }:
 
-{% block variables %}{% endblock %}
+{% block variables %}{% endblock -%}
+
 {
   name = "{{ project_name | replace('_', '-')}}";
   # https://devenv.sh/basics/
   env = {
     GREET = "🛠️ Let's hack ";
-    {% block env %}{% endblock %}
+    {%- block env %}{% endblock %}
   };
 
   # https://devenv.sh/scripts/
-  scripts.hello.exec = "echo $GREET";
-  scripts.cat.exec = ''
-    bat "$@";
-  '';
+  scripts = {
+    hello.exec = "echo $GREET";
+    cat.exec = "bat $@";
 
-  {% block script %}{% endblock %}
+    show = {
+      # Prints scripts that have a description
+      # Adapted from https://github.com/cachix/devenv/blob/ef61728d91ad5eb91f86cdbcc16070602e7afa16/examples/scripts/devenv.nix#L34
+      exec = ''
+        GREEN="\033[0;32m";
+        YELLOW="\033[33m";
+        NC="\033[0m";
+        echo
+        echo -e "✨ Helper scripts you can run to make your development richer:"
+        echo
+        ${pkgs.gnused}/bin/sed -e 's| |••|g' -e 's|=| |' <<EOF | ${pkgs.util-linuxMinimal}/bin/column -t | ${pkgs.gnused}/bin/sed -e "s|^\([^ ]*\)|$(printf "$GREEN")\1$(printf "$NC"):    |" -e "s|^|$(printf "$YELLOW*$NC") |" -e 's|••| |g'
+        ${lib.generators.toKeyValue { } (
+          lib.mapAttrs (name: value: value.description) (
+            lib.filterAttrs (_: value: value.description != "") config.scripts
+          )
+        )}
+        EOF
+        echo
+      '';
+      description = "Print this message and exit.";
+    };
+
+    {% block scripts %}{% endblock -%}
+  };
 
   # https://devenv.sh/packages/
   packages = with pkgs; [
@@ -29,14 +52,20 @@
     bat
     jq
     tealdeer
-    {% block packages %}{% endblock %}
+    {%- block packages %}{% endblock -%}
   ];
 
   languages = {
-    {% block languages %}{% endblock %}
+    {%- block languages %}{% endblock -%}
   };
 
-  {% block extra_config %}{% endblock %}
+  enterShell = ''
+    hello
+    show
+    {%- block enter_shell %}{% endblock -%}
+  '';
+
+  {% block extra_config %}{% endblock -%}
 
   # https://devenv.sh/pre-commit-hooks/
   pre-commit.hooks = {
@@ -48,7 +77,7 @@
       enable = true;
       settings.preset = "relaxed";
     };
-    {% block hooks %}{% endblock %}
+    {%- block hooks %}{% endblock -%}
   };
 
   # Make diffs fantastic

--- a/includes/direnv.gitignore
+++ b/includes/direnv.gitignore
@@ -1,3 +1,2 @@
 ### direnv ###
 .direnv
-.envrc

--- a/template/{% if language == 'Python' %}{{ project_name }}{% endif %}/devenv.nix.jinja
+++ b/template/{% if language == 'Python' %}{{ project_name }}{% endif %}/devenv.nix.jinja
@@ -2,18 +2,18 @@
 
 {% block variables %}
 let
-  python-packages = p: with p; [ pip python-lsp-server epc black pylint ];
+  python-packages = p: with p; [ pip python-lsp-server epc pylint ];
 in
 {% endblock %}
 
 {% block languages %}
   python = {
     enable = true;
-    {% if python_package_manager == "PDM" %}
+    {% if python_package_manager == "PDM" -%}
     venv = {
       enable = true;
     };
-    {% elif python_package_manager == "Poetry" %}
+    {% elif python_package_manager == "Poetry" -%}
     poetry = {
       enable = true;
       activate.enable = true;
@@ -21,7 +21,7 @@ in
       install.allExtras = true;
       install.groups = [ "dev" ];
     };
-    {% endif %}
+    {% endif -%}
   };
 {% endblock %}
 
@@ -32,32 +32,34 @@ libz # fix: for numpy/pandas import
 (python3.withPackages python-packages)
 {% endblock %}
 
-{% block script %}
-  # This script is temporary due to two problems:
-  #  1. `cz` requires a personal github token to publish a release https://commitizen-tools.github.io/commitizen/tutorials/github_actions/
-  #  2. `cz bump` fails to sign in a terminal: https://github.com/commitizen-tools/commitizen/issues/1184
-  scripts.release = {
+{% block scripts %}
+  release = {
+    # This script is temporary due to two problems:
+    #  1. `cz` requires a personal github token to publish a release https://commitizen-tools.github.io/commitizen/tutorials/github_actions/
+    #  2. `cz bump` fails to sign in a terminal: https://github.com/commitizen-tools/commitizen/issues/1184
     exec = ''
       rm CHANGELOG.md
       cz bump --files-only --check-consistency
       git tag $(python -c "from src.{{ project_name }} import __version__; print(__version__)")
     '';
-    description = ''
-      Release a new version and update the CHANGELOG.
-    '';
+    description = "Release a new version and update the CHANGELOG.";
+  };
+
+  pyfix = {
+    exec = "ruff check . --fix && ruff format .";
+    description = "Lint, (possibly) fix and apply formatting to python files";
   };
 {% endblock %}
 
-{% block extra_config %}
-enterShell = ''
-  hello
-  {% if python_package_manager == "PDM" %}
-  pdm install
-  {% endif %}
-'';
+{% block enter_shell %}
+    {% if python_package_manager == "PDM" %}
+    pdm install
+    {% endif -%}
 {% endblock %}
+
+{% block extra_config %}{% endblock %}
+
 {% block hooks %}
     ruff.enable = true;
     editorconfig-checker.enable = true;
-    black.enable = true;
 {% endblock %}

--- a/template/{% if language == 'Python' %}{{ project_name }}{% endif %}/devenv.nix.jinja
+++ b/template/{% if language == 'Python' %}{{ project_name }}{% endif %}/devenv.nix.jinja
@@ -47,7 +47,7 @@ libz # fix: for numpy/pandas import
 
   pyfix = {
     exec = "ruff check . --fix && ruff format .";
-    description = "Lint, (possibly) fix and apply formatting to python files";
+    description = "Lint, (possibly) fix and apply formatting to python files.";
   };
 {% endblock %}
 

--- a/template/{% if language == 'Python' %}{{ project_name }}{% endif %}/pyproject.toml.jinja
+++ b/template/{% if language == 'Python' %}{{ project_name }}{% endif %}/pyproject.toml.jinja
@@ -75,7 +75,8 @@ select = [
   "E",  # pycodestyle
   "F",  # pyflakes
   "UP", # pyupgrade
-  "D"   # pydocstyle
+  "D",  # pydocstyle
+  "I",  # isort
 ]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
In this PR:

- Use Ruff only for Python linting and formatting (disable Black)
- Add isort linting rules

Also:
- Add `show` script to base template: prints all available commands with descriptions
- Improve jinja block formatting
- Bundle all scripts under single `script` object to improve readability
- Keep `.envrc` files in new repos (use `.env` to set local env variables).