### PR TITLE
fix: remove node_modules from base template

### DIFF
--- a/includes/base.nix.jinja
+++ b/includes/base.nix.jinja
@@ -105,7 +105,7 @@
   pre-commit.hooks = {
     nixfmt-rfc-style = {
       enable = true;
-      excludes = [ ".devenv.flake.nix" "node_modules/**" ];
+      excludes = [ ".devenv.flake.nix" ];
     };
     yamllint = {
       enable = true;


### PR DESCRIPTION
It's not required to have node_modules on base template.