### PR TITLE
Add Nix cache to the CI and Github Actions templates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   tests:
+    permissions:
+      actions: write
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -32,3 +35,5 @@ jobs:
         if: always()
         with:
           primary-key: ${{ runner.os }}-nix
+          purge: true
+          purge-primary-key: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v30
       - uses: nix-community/cache-nix-action/restore@v6
+        id: cache-restore
         with:
           primary-key: ${{ runner.os }}-nix
       - uses: cachix/cachix-action@v14
@@ -32,7 +33,7 @@ jobs:
         run: devenv test
 
       - uses: nix-community/cache-nix-action/save@v6
-        if: always()
+        if: always() && (steps.cache-restore.outputs.hit-primary-key != 'true' || contains(github.event.files, '*.lock'))
         with:
           primary-key: ${{ runner.os }}-nix
           purge: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,10 @@ jobs:
         run: devenv test
 
       - uses: nix-community/cache-nix-action/save@v6
-        if: always() && (steps.cache-restore.outputs.hit-primary-key != 'true' || contains(github.event.files, '*.lock'))
+        if: |
+          always() &&
+          (steps.cache-restore.outputs.hit-primary-key != 'true' ||
+           contains(github.event.files, '*.lock'))
         with:
           primary-key: ${{ runner.os }}-nix
           purge: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v26
+      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nix-community/cache-nix-action/restore@v6
+        with:
+          primary-key: ${{ runner.os }}-nix
       - uses: cachix/cachix-action@v14
         with:
           name: devenv
@@ -24,3 +27,8 @@ jobs:
 
       - name: Build the devenv shell and run any pre-commit hooks
         run: devenv test
+
+      - uses: nix-community/cache-nix-action/save@v6
+        if: always()
+        with:
+          primary-key: ${{ runner.os }}-nix

--- a/template/Go/.github/workflows/test.yml
+++ b/template/Go/.github/workflows/test.yml
@@ -15,7 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v26
+      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nix-community/cache-nix-action/restore@v6
+        with:
+          primary-key: ${{ runner.os }}-nix
       - uses: cachix/cachix-action@v14
         with:
           name: devenv
@@ -24,3 +27,7 @@ jobs:
 
       - name: Build the devenv shell and run any pre-commit hooks
         run: devenv test
+      - uses: nix-community/cache-nix-action/save@v6
+        if: always()
+        with:
+          primary-key: ${{ runner.os }}-nix

--- a/template/Go/.github/workflows/test.yml
+++ b/template/Go/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v30
       - uses: nix-community/cache-nix-action/restore@v6
+        id: cache-restore
         with:
           primary-key: ${{ runner.os }}-nix
       - uses: cachix/cachix-action@v14
@@ -31,7 +32,10 @@ jobs:
       - name: Build the devenv shell and run any pre-commit hooks
         run: devenv test
       - uses: nix-community/cache-nix-action/save@v6
-        if: always()
+        if: |
+          always() &&
+          (steps.cache-restore.outputs.hit-primary-key != 'true' ||
+           contains(github.event.files, '*.lock'))
         with:
           primary-key: ${{ runner.os }}-nix
           purge: true

--- a/template/Go/.github/workflows/test.yml
+++ b/template/Go/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   tests:
+    permissions:
+      actions: write
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -31,3 +34,5 @@ jobs:
         if: always()
         with:
           primary-key: ${{ runner.os }}-nix
+          purge: true
+          purge-primary-key: always

--- a/template/Node.js/.github/workflows/test.yml
+++ b/template/Node.js/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   tests:
+    permissions:
+      actions: write
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -32,3 +35,5 @@ jobs:
         if: always()
         with:
           primary-key: ${{ runner.os }}-nix
+          purge: true
+          purge-primary-key: always

--- a/template/Node.js/.github/workflows/test.yml
+++ b/template/Node.js/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v30
       - uses: nix-community/cache-nix-action/restore@v6
+        id: cache-restore
         with:
           primary-key: ${{ runner.os }}-nix
       - uses: cachix/cachix-action@v14
@@ -32,7 +33,10 @@ jobs:
         run: devenv test
 
       - uses: nix-community/cache-nix-action/save@v6
-        if: always()
+        if: |
+          always() &&
+          (steps.cache-restore.outputs.hit-primary-key != 'true' ||
+           contains(github.event.files, '*.lock'))
         with:
           primary-key: ${{ runner.os }}-nix
           purge: true

--- a/template/Node.js/.github/workflows/test.yml
+++ b/template/Node.js/.github/workflows/test.yml
@@ -15,7 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v26
+      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nix-community/cache-nix-action/restore@v6
+        with:
+          primary-key: ${{ runner.os }}-nix
       - uses: cachix/cachix-action@v14
         with:
           name: devenv
@@ -24,3 +27,8 @@ jobs:
 
       - name: Build the devenv shell and run any pre-commit hooks
         run: devenv test
+
+      - uses: nix-community/cache-nix-action/save@v6
+        if: always()
+        with:
+          primary-key: ${{ runner.os }}-nix

--- a/template/Python/.github/workflows/test.yml
+++ b/template/Python/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   tests:
+    permissions:
+      actions: write
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -32,3 +35,5 @@ jobs:
         if: always()
         with:
           primary-key: ${{ runner.os }}-nix
+          purge: true
+          purge-primary-key: always

--- a/template/Python/.github/workflows/test.yml
+++ b/template/Python/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v30
       - uses: nix-community/cache-nix-action/restore@v6
+        id: cache-restore
         with:
           primary-key: ${{ runner.os }}-nix
       - uses: cachix/cachix-action@v14
@@ -32,7 +33,10 @@ jobs:
         run: devenv test
 
       - uses: nix-community/cache-nix-action/save@v6
-        if: always()
+        if: |
+          always() &&
+          (steps.cache-restore.outputs.hit-primary-key != 'true' ||
+           contains(github.event.files, '*.lock'))
         with:
           primary-key: ${{ runner.os }}-nix
           purge: true

--- a/template/Python/.github/workflows/test.yml
+++ b/template/Python/.github/workflows/test.yml
@@ -15,7 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v26
+      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nix-community/cache-nix-action/restore@v6
+        with:
+          primary-key: ${{ runner.os }}-nix
       - uses: cachix/cachix-action@v14
         with:
           name: devenv
@@ -24,3 +27,8 @@ jobs:
 
       - name: Build the devenv shell and run any pre-commit hooks
         run: devenv test
+
+      - uses: nix-community/cache-nix-action/save@v6
+        if: always()
+        with:
+          primary-key: ${{ runner.os }}-nix

--- a/template/Rust/.github/workflows/test.yml
+++ b/template/Rust/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   tests:
+    permissions:
+      actions: write
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -32,3 +35,5 @@ jobs:
         if: always()
         with:
           primary-key: ${{ runner.os }}-nix
+          purge: true
+          purge-primary-key: always

--- a/template/Rust/.github/workflows/test.yml
+++ b/template/Rust/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v30
       - uses: nix-community/cache-nix-action/restore@v6
+        id: cache-restore
         with:
           primary-key: ${{ runner.os }}-nix
       - uses: cachix/cachix-action@v14
@@ -32,7 +33,10 @@ jobs:
         run: devenv test
 
       - uses: nix-community/cache-nix-action/save@v6
-        if: always()
+        if: |
+          always() &&
+          (steps.cache-restore.outputs.hit-primary-key != 'true' ||
+           contains(github.event.files, '*.lock'))
         with:
           primary-key: ${{ runner.os }}-nix
           purge: true

--- a/template/Rust/.github/workflows/test.yml
+++ b/template/Rust/.github/workflows/test.yml
@@ -15,7 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v26
+      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nix-community/cache-nix-action/restore@v6
+        with:
+          primary-key: ${{ runner.os }}-nix
       - uses: cachix/cachix-action@v14
         with:
           name: devenv
@@ -24,3 +27,8 @@ jobs:
 
       - name: Build the devenv shell and run any pre-commit hooks
         run: devenv test
+
+      - uses: nix-community/cache-nix-action/save@v6
+        if: always()
+        with:
+          primary-key: ${{ runner.os }}-nix


### PR DESCRIPTION
- Use `nix-community/cache-nix-action/restore` and `nix-community/cache-nix-action/save` actions to cache Nix packages.
- Use `always()` condition for the `save` action to also cache in case of test failures.
- Remove `cachix/install-nix-action` in favor of `nixbuild/nix-quick-install-action` because of [`nix-community/cache-nix-action` limitations](https://github.com/nix-community/cache-nix-action/tree/main?tab=readme-ov-file#limitations).